### PR TITLE
Add nix-shell for nix/nixos users

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ You can download and run already built binaries from [releases](https://github.c
 You can build Alfis by issuing `cargo build` and `cargo run` commands in a directory of cloned repository.
 If you want to build release version you need to do `cargo build --release` as usual.
 
-If you have the Nix package manager on Linux/Mac/Windows, an initial `shell.nix` is provided that provides build tools and dependencies. Run `nix-shell` to enter it, then run `cargo build` and `cargo run` as listed above.
-
 ### ![Windows Logo](/img/windows.svg) On Windows
 You don't need any additional steps to build Alfis, just stick to the MSVC version of Rust.
 
@@ -58,8 +56,8 @@ Install from available [AUR package](https://aur.archlinux.org/packages/alfis) c
 yay -S alfis
 ```
 
-### On NixOS
-`nix-shell` in this repo and then run `cargo build` and `cargo install` after you have entered the shell
+### On Nix/NixOS
+`nix-shell` in this repo and then run `cargo build` and `cargo install` after you have entered the shell.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ You can download and run already built binaries from [releases](https://github.c
 You can build Alfis by issuing `cargo build` and `cargo run` commands in a directory of cloned repository.
 If you want to build release version you need to do `cargo build --release` as usual.
 
+If you have the Nix package manager on Linux/Mac/Windows, an initial `shell.nix` is provided that provides build tools and dependencies. Run `nix-shell` to enter it, then run `cargo build` and `cargo run` as listed above.
+
 ### ![Windows Logo](/img/windows.svg) On Windows
 You don't need any additional steps to build Alfis, just stick to the MSVC version of Rust.
 
@@ -55,6 +57,9 @@ Install from available [AUR package](https://aur.archlinux.org/packages/alfis) c
 ```sh
 yay -S alfis
 ```
+
+### On NixOS
+`nix-shell` in this repo and then run `cargo build` and `cargo install` after you have entered the shell
 
 ## Installation
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+let
+  # Pinned nixpkgs, deterministic. Last updated: 2/12/21.
+  pkgs = import (fetchTarball("https://github.com/NixOS/nixpkgs/archive/a58a0b5098f0c2a389ee70eb69422a052982d990.tar.gz")) {};
+
+  # Rolling updates, not deterministic.
+  # pkgs = import (fetchTarball("channel:nixpkgs-unstable")) {};
+
+in pkgs.mkShell {
+  buildInputs = [ pkgs.cargo pkgs.rustc pkgs.webkitgtk pkgs.pkg-config pkgs.kdialog];
+}


### PR DESCRIPTION
Added `shell.nix` so nix package manager users can run `nix-shell` to enter a build environment, and edited README to that effect.