### PR TITLE
Add armlf architecture support

### DIFF
--- a/.github/workflows/rust_create_release.yml
+++ b/.github/workflows/rust_create_release.yml
@@ -82,6 +82,7 @@ jobs:
           PKGARCH=mips contrib/deb/generate.sh
           PKGARCH=mipsel contrib/deb/generate.sh
           PKGARCH=armhf contrib/deb/generate.sh
+          PKGARCH=armlf contrib/deb/generate.sh
           PKGARCH=arm64 contrib/deb/generate.sh
 
       - name: Upload bins & debs

--- a/contrib/deb/generate.sh
+++ b/contrib/deb/generate.sh
@@ -35,9 +35,10 @@ elif [ $PKGARCH = "i686" ]; then TARGET='i686-unknown-linux-musl'
 elif [ $PKGARCH = "mipsel" ]; then TARGET='mipsel-unknown-linux-musl'
 elif [ $PKGARCH = "mips" ]; then TARGET='mips-unknown-linux-musl'
 elif [ $PKGARCH = "armhf" ]; then TARGET='armv7-unknown-linux-musleabihf'
+elif [ $PKGARCH = "armlf" ]; then TARGET='arm-unknown-linux-musleabi'
 elif [ $PKGARCH = "arm64" ]; then TARGET='aarch64-unknown-linux-musl'
 else
-  echo "Specify PKGARCH=amd64,i686,mips,mipsel,armhf,arm64"
+  echo "Specify PKGARCH=amd64,i686,mips,mipsel,armhf,armlf,arm64"
   exit 1
 fi
 


### PR DESCRIPTION
In release artifacts missing Debian packages for armlf (armv6) architecture, but some devices running on this arch (e. g. Raspberry Pi 1/Zero). This lack not allows create network node running Yggdrasil (supports armlf) + ALFIS.

Pull request modifies Debian package build script, adding new section in select target architecture switch.