### PR TITLE
build: reduce Docker image size

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu
+FROM debian:stretch-slim
 
 LABEL Description="Alfis Alternative Free Identity System"
-LABEL URL="https://github.com/Revertron/Alfis/releases "
+LABEL URL="https://github.com/Revertron/Alfis/releases"
 
 ARG arch=amd64
 ARG srv_port=4244

--- a/contrib/docker/Dockerfile.alpine
+++ b/contrib/docker/Dockerfile.alpine
@@ -1,0 +1,23 @@
+FROM alpine:3.15
+
+LABEL Description="Alfis Alternative Free Identity System"
+LABEL URL="https://github.com/Revertron/Alfis/releases"
+
+ARG arch=amd64
+ARG srv_port=4244
+ARG dns_port=53
+
+RUN apk add --no-cache curl && \
+    curl -SsL "https://github.com/Revertron/Alfis/releases/download/$(curl --silent "https://api.github.com/repos/Revertron/Alfis/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')/alfis-linux-${arch}-$(curl --silent "https://api.github.com/repos/Revertron/Alfis/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')-nogui" -o /usr/bin/alfis && \
+    chmod a+x /usr/bin/alfis && \
+    apk del curl
+
+RUN /usr/bin/alfis -g > /etc/alfis.conf
+
+EXPOSE ${srv_port}
+EXPOSE ${dns_port}
+EXPOSE ${dns_port}/udp
+
+WORKDIR /var/lib/alfis
+
+CMD ["/usr/bin/alfis", "-n", "-c", "/etc/alfis.conf"]


### PR DESCRIPTION
Ubuntu image contains many things that are unnecessary to run ALFIS, cause ALFIS binary is self contained and has a minimum of dependencies. Base Debian slim image is smaller than Ubuntu by 17 MB, and Alpine Linux by 67 MB.

Usage of these images as base significant reduce result Docker image size:
```
REPOSITORY      TAG               IMAGE ID           SIZE
alfis           ubuntu            992b705a33cb       115MB
alfis           alpine            2f9d5bbf9abc       8.07MB
alfis           stretch-slim      86031758ae36       76.6MB
```

This merge request contains modification of Dockerfile for use Debian slim image as base. Also added Dockerfile for Alpine Linux-based distribution. 