### PR TITLE
Add OpenBSD support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,9 @@ thread-priority = "0.8.0"
 [target.'cfg(target_os = "linux")'.dependencies]
 thread-priority = "0.8.0"
 
+[target.'cfg(target_os = "openbsd")'.dependencies]
+thread-priority = "0.8.1"
+
 [build-dependencies]
 winres = "0.1.12"
 

--- a/src/commons/mod.rs
+++ b/src/commons/mod.rs
@@ -145,6 +145,12 @@ pub fn setup_miner_thread(cpu: u32) {
     let _ = set_current_thread_priority(ThreadPriority::Min);
 }
 
+#[cfg(target_os = "openbsd")]
+#[allow(unused_variables)]
+pub fn setup_miner_thread(cpu: u32) {
+    let _ = set_current_thread_priority(ThreadPriority::Min);
+}
+
 #[cfg(target_os = "macos")]
 #[allow(unused_variables)]
 pub fn setup_miner_thread(cpu: u32) {


### PR DESCRIPTION
Current version has `thead-priority` crate dependency set for linux, windows and macos,
but it seems that OpenBSD needs it too. 

Also `thread-priority` with version lower than 0.8.1 could not be built on OpenBSD,
that's why it's increased in Cargo.toml (I think it's also safe to increase it for other platforms).

Milestones for future upgrades:
* test that GUI is working properly
* add support for plegde(2) and unveil(2) to restrict permissions and filesystem access after initialization
* add rc.d script to use with OpenBSD's service system
* package alfis as a port

And just a sidenote: alfis could be built only on OpenBSD-current as for now (because of rust version), but soon enough when OpenBSD-7.1 will come out, this should not be an issue.