### PR TITLE
Add support for other BSDs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,11 +52,8 @@ open = { version = "2.1.1", optional = true }
 winapi = { version = "0.3.9", features = ["impl-default", "wincon", "shellscalingapi"] }
 thread-priority = "0.8.0"
 
-[target.'cfg(target_os = "linux")'.dependencies]
-thread-priority = "0.8.0"
-
-[target.'cfg(target_os = "openbsd")'.dependencies]
-thread-priority = "0.8.1"
+[target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
+thread-priority = "0.8.2"
 
 [build-dependencies]
 winres = "0.1.12"

--- a/src/commons/mod.rs
+++ b/src/commons/mod.rs
@@ -3,7 +3,7 @@ use std::num;
 
 pub use constants::*;
 use rand::Rng;
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "dragonfly")))]
 use thread_priority::*;
 
 use crate::dns::protocol::DnsRecord;
@@ -139,19 +139,13 @@ pub fn setup_miner_thread(cpu: u32) {
     //let _ = set_current_thread_ideal_processor(IdealProcessor::from(cpu));
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "openbsd", target_os = "freebsd", target_os = "netbsd"))]
 #[allow(unused_variables)]
 pub fn setup_miner_thread(cpu: u32) {
     let _ = set_current_thread_priority(ThreadPriority::Min);
 }
 
-#[cfg(target_os = "openbsd")]
-#[allow(unused_variables)]
-pub fn setup_miner_thread(cpu: u32) {
-    let _ = set_current_thread_priority(ThreadPriority::Min);
-}
-
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "dragonfly"))]
 #[allow(unused_variables)]
 pub fn setup_miner_thread(cpu: u32) {
     // MacOS is not supported by thread_priority crate


### PR DESCRIPTION
Tested basic functionality[1] on these systems:
FreeBSD
NetBSD
DragonflyBSD

[1]: by basic functionality I mean syncing the blockchain and resolving
DNS queries.

GUI doesn't work on NetBSD due to different locations of shared libraries which could be fixed.

DragonflyBSD isn't supported by `webview-sys` create so GUI doen't work there too. Also DragonflyBSD
isn't supported by `thread-priority` crate, so it is disabled in the code.

Also dependency check is now in one line instead of separate checks for each system to avoid duplicated code.