### PR TITLE
set default mining threads to 1

### DIFF
--- a/alfis.toml
+++ b/alfis.toml
@@ -33,6 +33,6 @@ forwarders = ["94.140.14.14:53", "94.140.15.15:53"]
 #Mining options
 [mining]
 # How many CPU threads to spawn for mining, zero = number of CPU cores
-threads = 0
+threads = 1
 # Set lower priority for mining threads
 lower = true


### PR DESCRIPTION
Application freeze my system on mining with unlimited threads. Until the threads selection implemented in GUI, suppose the better idea to set this value to 1

Regards