### PR TITLE
build: create build for armv6

### DIFF
--- a/.github/workflows/rust_parallel_release.yml
+++ b/.github/workflows/rust_parallel_release.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [ amd64, i686, mips, mipsel, armhf, arm64 ]
+        arch: [ amd64, i686, mips, mipsel, armhf, armlf, arm64 ]
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
In my last PR build for ARMv6 was introduced. But releases still publishes without armlf nogui package.
This changes will add build for armlf package in release.