### PR TITLE
Correctly scale nixos logo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ emerge --sync dm9pZCAq
 emerge net-dns/alfis
 ```
 
-### ![NixOS Logo](https://nixos.org/favicon.ico) On Nix/NixOS
+### <img src="https://nixos.org/favicon.ico" alt="NixOS Logo" style="height: 1em"> On Nix/NixOS
 `nix-shell` in this repo and then run `cargo build --release` and `cargo install` after you have entered the shell.
 
 ## Installation


### PR DESCRIPTION
Before:
![Screenshot_20250206_174517_Firefox](https://github.com/user-attachments/assets/4f0eb55a-8c02-4712-afb6-57f7c35dee76)
After:
![Screenshot_20250206_175059_Firefox](https://github.com/user-attachments/assets/5b3d2cb9-56a3-42da-8475-f120f2af9be4)

