### PR TITLE
Fix Docker container timeout issue when processing large TXT records

### DIFF
--- a/src/commons/constants.rs
+++ b/src/commons/constants.rs
@@ -48,7 +48,7 @@ pub const POLL_TIMEOUT: Option<Duration> = Some(Duration::from_millis(200));
 pub const WAIT_FOR_INTERNET: Duration = Duration::from_secs(10);
 /// We start syncing blocks only when we got 4 and more connected nodes
 pub const MIN_CONNECTED_NODES_START_SYNC: usize = 4;
-pub const MAX_READ_BLOCK_TIME: u128 = 100;
+pub const MAX_READ_BLOCK_TIME: u128 = 1000;
 pub const MAX_RECONNECTS: u32 = 5;
 pub const MAX_IDLE_SECONDS: u64 = 180;
 pub const MAX_NODES: usize = 15;


### PR DESCRIPTION
Increased MAX_READ_BLOCK_TIME from 100ms to 1000ms to resolve issue where Alfis would get stuck on block #16596 containing large TXT records when running in Docker/Podman containers. The original 100ms timeout was insufficient for the slower I/O performance typically seen in containerized environments, causing the block processing to timeout and hang.

This change allows adequate time for block processing in container environments while maintaining reasonable performance for native execution.

🤖 Generated with [Claude Code](https://claude.ai/code)